### PR TITLE
platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Replay is an event traffic replay service. It was formerly presented as [The Und
     Obtain the Google Application Credentials file, and put the file path to it in your config.yaml's `GOOGLE_APPLICATION_CREDENTIALS`.
 
 ## Run
-1. `go build -o bin/main *.go && ./bin/main`
+1. `go build -o bin/main *.go`
 2. `./bin/main`
 2. Look for your events in your projects on Sentry.io.
 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,6 @@ go build -o bin/main *.go && ./bin/main
 
 [Sentry Developer Documentation](https://develop.sentry.dev/sdk/store)
 
+For some JSON files you have to manually change the platform. For instance, java errors and android errors both have `platform:java` so change the android one to `platform:android`. And other sdk's simply report a value of `platform:other` which isn't helpful for Replay to know what kind of error it is. This is a flawed design. Ideally, should decide based on the `Sdk.name` value.
+
 This project was originally called Undertaker because it featured a proxy middleman that captured events on their way to Sentry. Today, we take the event JSON's from Sentry.io and place them in Cloud Storage.

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -115,8 +115,7 @@ func (d *DemoAutomation) getEventsFromGCS() []Event {
 			panic(err)
 		}
 
-		// event.setPlatform()
-		event.setDsnGCS()
+		event.setPlatform()
 		event.undertake()
 		events = append(events, event)
 		events = removeMechanism(events)

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -16,24 +16,6 @@ import (
 
 type DemoAutomation struct{}
 
-const JAVASCRIPT = "javascript"
-const PYTHON = "python"
-const JAVA = "java"
-const RUBY = "ruby"
-const GO = "go"
-const PHP = "php"
-const NODE = "node"
-const DART = "dart"
-const CSHARP = "csharp"
-const ELIXIR = "elixir"
-const PERL = "perl"
-const RUST = "native"
-const COCOA = "cocoa"
-const ANDROID = "android"
-
-// platforms := []string{"tst"}
-// const platforms = []string{"test", "test2"}
-
 // Get events from both Sentry and GCS
 func (d *DemoAutomation) getEvents() []Event {
 	var events []Event

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -31,6 +31,9 @@ const RUST = "native"
 const COCOA = "cocoa"
 const ANDROID = "android"
 
+// platforms := []string{"tst"}
+// const platforms = []string{"test", "test2"}
+
 // Get events from both Sentry and GCS
 func (d *DemoAutomation) getEvents() []Event {
 	var events []Event

--- a/discoverAPI.go
+++ b/discoverAPI.go
@@ -29,7 +29,8 @@ type EventMetadata struct {
 func (d DiscoverAPI) latestEventMetadata(org string, n int) []EventMetadata {
 	fmt.Printf("\n> ORG %v\n", org)
 
-	query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST, COCOA, ANDROID})
+	// query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST, COCOA, ANDROID})
+	query := makeQuery(platforms)
 	endpoint := fmt.Sprintf("https://sentry.io/api/0/organizations/%v/eventsv2/?statsPeriod=24h&field=event.type&field=project&field=platform&per_page=%v&query=%v", org, strconv.Itoa(n), query)
 
 	request, _ := http.NewRequest("GET", endpoint, nil)

--- a/discoverAPI.go
+++ b/discoverAPI.go
@@ -27,9 +27,6 @@ type EventMetadata struct {
 // Returns event metadata (e.g. Id, Project) but not the entire Event itself, which gets queried separately.
 // n of 200 may not work
 func (d DiscoverAPI) latestEventMetadata(org string, n int) []EventMetadata {
-	fmt.Printf("\n> ORG %v\n", org)
-
-	// query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST, COCOA, ANDROID})
 	query := makeQuery(platforms)
 	endpoint := fmt.Sprintf("https://sentry.io/api/0/organizations/%v/eventsv2/?statsPeriod=24h&field=event.type&field=project&field=platform&per_page=%v&query=%v", org, strconv.Itoa(n), query)
 
@@ -63,11 +60,11 @@ func makeQuery(supportedPlatforms []string) string {
 	for _, platform := range supportedPlatforms {
 		result += "platform.name%3A" + platform + "+OR+"
 	}
-	// slice the final "+OR+" off
+	// slices the final "+OR+" off
 	return result[:len(result)-4]
 }
 
-// Consider chaining
+// EVAL chaining
 // func (d DiscoverAPI) execute() {
-// //
+//
 // }

--- a/event.go
+++ b/event.go
@@ -75,7 +75,23 @@ func (event *Event) setDsn(dsn string) {
 	}
 }
 
-func (event *Event) setDsnGCS() {
+// func (event *Event) setDsnGCS() {
+// 	for _, platform := range platforms {
+// 		if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == platform {
+// 			event.Platform = platform
+// 			break
+// 		} else if event.Kind == TRANSACTION && event.Transaction.Platform == platform {
+// 			event.Platform = platform
+// 			break
+// 		}
+// 	}
+// 	if event.Platform == "" {
+// 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
+// 		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
+// 	}
+// }
+
+func (event *Event) setPlatform() {
 	for _, platform := range platforms {
 		if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == platform {
 			event.Platform = platform
@@ -89,109 +105,23 @@ func (event *Event) setDsnGCS() {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
 	}
-
-	// if event.Kind == TRANSACTION && event.Transaction.Platform == JAVASCRIPT {
-	// 	event.Platform = JAVASCRIPT
-	// } else if event.Kind == TRANSACTION && event.Transaction.Platform == PYTHON {
-	// 	event.Platform = PYTHON
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVASCRIPT {
-	// 	event.Platform = JAVASCRIPT
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PYTHON {
-	// 	event.Platform = PYTHON
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVA {
-	// 	event.Platform = JAVA
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUBY {
-	// 	event.Platform = RUBY
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == GO {
-	// 	event.Platform = GO
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PHP {
-	// 	event.Platform = PHP
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == NODE {
-	// 	event.Platform = NODE
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == CSHARP {
-	// 	event.Platform = CSHARP
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == DART {
-	// 	event.Platform = DART
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ELIXIR {
-	// 	event.Platform = ELIXIR
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
-	// 	event.Platform = PERL
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
-	// 	event.Platform = RUST
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
-	// 	event.Platform = COCOA
-	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
-	// 	event.Platform = ANDROID
-	// } else {
-	// 	sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-	// 	log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
-	// }
 }
 
-// TODO Do Not Repeat Yourself DRY
-func (event *Event) setPlatform() {
-	if event.Kind == TRANSACTION && event.Transaction.Platform == JAVASCRIPT {
-		event.Platform = JAVASCRIPT
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == PYTHON {
-		event.Platform = PYTHON
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == JAVA {
-		event.Platform = JAVA
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == RUBY {
-		event.Platform = RUBY
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == GO {
-		event.Platform = GO
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == PHP {
-		event.Platform = PHP
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == NODE {
-		event.Platform = NODE
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVASCRIPT {
-		event.Platform = JAVASCRIPT
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PYTHON {
-		event.Platform = PYTHON
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVA {
-		event.Platform = JAVA
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUBY {
-		event.Platform = RUBY
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == GO {
-		event.Platform = GO
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PHP {
-		event.Platform = PHP
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == NODE {
-		event.Platform = NODE
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == CSHARP {
-		event.Platform = CSHARP
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == DART {
-		event.Platform = DART
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ELIXIR {
-		event.Platform = ELIXIR
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
-		event.Platform = PERL
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
-		event.Platform = RUST
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
-		event.Platform = COCOA
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
-		event.Platform = ANDROID
-	} else {
-		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-		log.Fatal("setPlatform() event.Kind and type not recognized " + event.Kind + " " + event.Error.Platform)
-	}
-}
-
+// Undertaker adds the replay tag
 func (e Event) undertake() {
 	if e.Kind == ERROR || e.Kind == DEFAULT {
 		if e.Error.Tags == nil {
 			e.Error.Tags = make([][]string, 0)
 		}
-		// EVAL if []Tags already has 'replay', then it gets duplicated in the array, but doesn't error in Sentry
-		tagItem := []string{"replay", "replay"}
-		e.Error.Tags = append(e.Error.Tags, tagItem)
+		// TODO if []Tags already has 'replay', then it gets duplicated in the array, but doesn't error in Sentry
+		// tagItem := []string{"replay", "replay"}
+		// e.Error.Tags = append(e.Error.Tags, tagItem)
 	}
 	if e.Kind == TRANSACTION {
 		if e.Transaction.Tags == nil {
 			e.Transaction.Tags = make([][]string, 0)
 		}
-		tagItem := []string{"replay", "replay"}
-		e.Transaction.Tags = append(e.Transaction.Tags, tagItem)
+		// tagItem := []string{"replay", "replay"}
+		// e.Transaction.Tags = append(e.Transaction.Tags, tagItem)
 	}
 }

--- a/event.go
+++ b/event.go
@@ -87,7 +87,7 @@ func (event *Event) setPlatform() {
 	}
 	if event.Platform == "" {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
+		log.Fatalf("event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
 	}
 }
 

--- a/event.go
+++ b/event.go
@@ -75,22 +75,6 @@ func (event *Event) setDsn(dsn string) {
 	}
 }
 
-// func (event *Event) setDsnGCS() {
-// 	for _, platform := range platforms {
-// 		if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == platform {
-// 			event.Platform = platform
-// 			break
-// 		} else if event.Kind == TRANSACTION && event.Transaction.Platform == platform {
-// 			event.Platform = platform
-// 			break
-// 		}
-// 	}
-// 	if event.Platform == "" {
-// 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-// 		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
-// 	}
-// }
-
 func (event *Event) setPlatform() {
 	for _, platform := range platforms {
 		if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == platform {

--- a/event.go
+++ b/event.go
@@ -60,6 +60,10 @@ func (event *Event) getPlatform() string {
 	if event.Kind == DEFAULT {
 		platform = event.Error.Platform
 	}
+	if platform == "" {
+		sentry.CaptureException(errors.New("no event platform set"))
+		log.Fatalf("no event platform set")
+	}
 	return platform
 }
 
@@ -71,44 +75,57 @@ func (event *Event) setDsn(dsn string) {
 	}
 }
 
-// TODO Do Not Repeat Yourself DRY
 func (event *Event) setDsnGCS() {
-	if event.Kind == TRANSACTION && event.Transaction.Platform == JAVASCRIPT {
-		event.Platform = JAVASCRIPT
-	} else if event.Kind == TRANSACTION && event.Transaction.Platform == PYTHON {
-		event.Platform = PYTHON
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVASCRIPT {
-		event.Platform = JAVASCRIPT
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PYTHON {
-		event.Platform = PYTHON
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVA {
-		event.Platform = JAVA
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUBY {
-		event.Platform = RUBY
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == GO {
-		event.Platform = GO
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PHP {
-		event.Platform = PHP
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == NODE {
-		event.Platform = NODE
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == CSHARP {
-		event.Platform = CSHARP
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == DART {
-		event.Platform = DART
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ELIXIR {
-		event.Platform = ELIXIR
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
-		event.Platform = PERL
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
-		event.Platform = RUST
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
-		event.Platform = COCOA
-	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
-		event.Platform = ANDROID
-	} else {
+	for _, platform := range platforms {
+		if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == platform {
+			event.Platform = platform
+			break
+		} else if event.Kind == TRANSACTION && event.Transaction.Platform == platform {
+			event.Platform = platform
+			break
+		}
+	}
+	if event.Platform == "" {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
 	}
+
+	// if event.Kind == TRANSACTION && event.Transaction.Platform == JAVASCRIPT {
+	// 	event.Platform = JAVASCRIPT
+	// } else if event.Kind == TRANSACTION && event.Transaction.Platform == PYTHON {
+	// 	event.Platform = PYTHON
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVASCRIPT {
+	// 	event.Platform = JAVASCRIPT
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PYTHON {
+	// 	event.Platform = PYTHON
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == JAVA {
+	// 	event.Platform = JAVA
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUBY {
+	// 	event.Platform = RUBY
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == GO {
+	// 	event.Platform = GO
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PHP {
+	// 	event.Platform = PHP
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == NODE {
+	// 	event.Platform = NODE
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == CSHARP {
+	// 	event.Platform = CSHARP
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == DART {
+	// 	event.Platform = DART
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ELIXIR {
+	// 	event.Platform = ELIXIR
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
+	// 	event.Platform = PERL
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
+	// 	event.Platform = RUST
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
+	// 	event.Platform = COCOA
+	// } else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
+	// 	event.Platform = ANDROID
+	// } else {
+	// 	sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
+	// 	log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
+	// }
 }
 
 // TODO Do Not Repeat Yourself DRY

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	config     Config
 	n          *int
 	counter    int
+	platforms  []string
 )
 
 func init() {
@@ -34,6 +35,8 @@ func init() {
 	defaultPrefix := "error"
 	filePrefix = flag.String("prefix", defaultPrefix, "file prefix")
 	flag.Parse()
+
+	platforms = []string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST, COCOA, ANDROID}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,21 @@ var (
 	platforms  []string
 )
 
+const JAVASCRIPT = "javascript"
+const PYTHON = "python"
+const JAVA = "java"
+const RUBY = "ruby"
+const GO = "go"
+const PHP = "php"
+const NODE = "node"
+const DART = "dart"
+const CSHARP = "csharp"
+const ELIXIR = "elixir"
+const PERL = "perl"
+const RUST = "rust"
+const COCOA = "cocoa"
+const ANDROID = "android"
+
 func init() {
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")

--- a/requests.go
+++ b/requests.go
@@ -13,99 +13,27 @@ type Requests struct {
 // TODO in each case met, check if len(config.Destinations.Platform) != 0
 // Doing each destination one-by-one, gives each org a rest before its API is called again, so don't insert a short Sleep Timeout yet
 func (r *Requests) send() {
+	var found bool
 	for _, event := range r.events {
-		switch event.Platform {
-		case JAVASCRIPT:
-			for _, dsn := range config.Destinations.Javascript {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
+		for _, platform := range platforms {
+			found = false
+			if platform == event.Platform {
+				found = true
+				for _, dsn := range config.Destinations[platform] {
+					event.setDsn(dsn)
+					request := NewRequest(event)
+					request.send()
+				}
+				break
 			}
-		case PYTHON:
-			for _, dsn := range config.Destinations.Python {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case JAVA:
-			for _, dsn := range config.Destinations.Java {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case RUBY:
-			for _, dsn := range config.Destinations.Ruby {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case GO:
-			for _, dsn := range config.Destinations.Go {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case PHP:
-			for _, dsn := range config.Destinations.Php {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case NODE:
-			for _, dsn := range config.Destinations.Node {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case CSHARP:
-			for _, dsn := range config.Destinations.Csharp {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case DART:
-			for _, dsn := range config.Destinations.Dart {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case ELIXIR:
-			for _, dsn := range config.Destinations.Elixir {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case PERL:
-			for _, dsn := range config.Destinations.Perl {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case RUST:
-			for _, dsn := range config.Destinations.Rust {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case COCOA:
-			for _, dsn := range config.Destinations.Cocoa {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		case ANDROID:
-			for _, dsn := range config.Destinations.Android {
-				event.setDsn(dsn)
-				request := NewRequest(event)
-				request.send()
-			}
-		default:
+		}
+		if found == false {
 			sentry.CaptureMessage("unsupported event platform: " + event.Platform)
 			fmt.Printf("\nunrecognized Platform %v\n", event.Platform)
 		}
 	}
 	fmt.Printf("\n> TOTAL sent: %v", counter)
 
-	// does not Capture, not sure why
+	// Does not Capture, not sure why
 	sentry.CaptureMessage("finished sending all requests")
 }

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"os/user"
 	"strings"
 	"time"
@@ -141,7 +140,7 @@ func parseYamlConfig() {
 	// 	msg = "no skip list provided"
 	// }
 	if config.SentryJobMonitor == "" {
-		msg = "no sentry"
+		msg = "no sentry job monitor dsn set"
 	}
 	if config.Environment == "" {
 		msg = "no environment"

--- a/utils.go
+++ b/utils.go
@@ -98,22 +98,7 @@ type Config struct {
 	SentryJobMonitor string
 	Environment      string
 	Sources          []string
-	Destinations     struct {
-		Javascript []string `yaml:"javascript"`
-		Python     []string `yaml:"python"`
-		Java       []string `yaml:"java"`
-		Ruby       []string `yaml:"ruby"`
-		Go         []string `yaml:"go"`
-		Php        []string `yaml:"php"`
-		Node       []string `yaml:"node"`
-		Csharp     []string `yaml:"csharp"`
-		Dart       []string `yaml:"dart"`
-		Elixir     []string `yaml:"elixir"`
-		Perl       []string `yaml:"perl"`
-		Rust       []string `yaml:"rust"`
-		Cocoa      []string `yaml:"cocoa"`
-		Android    []string `yaml:"android"`
-	}
+	Destinations     map[string][]string
 }
 
 func parseYamlConfig() {


### PR DESCRIPTION
Type of Change
- [x] Refactor

Full list of platforms now defined in `main.go`, and iterations on `platforms` list performed throughout the code base.

Rust events are now `platform:rust` as `platform:native` could be confused with other platforms/sdk's.

So in the JSON file, change it to `platform:rust`.